### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,17 +24,20 @@ repositories {
             includeGroup "dev.technici4n"
         }
     }
+    maven {
+        name = "BuildCraft"
+        url = "https://mod-buildcraft.com/maven"
+    }
 }
 
 dependencies {
-    modApi "dev.technici4n:FastTransferLib:${project.ftl_version}"
-    include "dev.technici4n:FastTransferLib:${project.ftl_version}}"
+    modApi include("dev.technici4n:FastTransferLib:${project.ftl_version}")
 }
 ```
 In `gradle.properties`:
 ```properties
 # put latest version here, check the commits!
-ftl_version=0.1.0
+ftl_version=0.1.1
 ```
 
 ## Usage


### PR DESCRIPTION
The modapi/include statements where redundant and had an extra right brace in them. FTL also depends on LibBlockAttributes, so I added the Maven repo that it uses.